### PR TITLE
CMake: Add explicit dependency for `driver` component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,4 +23,5 @@ endif()
 idf_component_register(SRCS "${srcs}"
                        REQUIRES "${requires}"
                        INCLUDE_DIRS "${includes}"
+                       REQUIRES driver
 )


### PR DESCRIPTION
This fixes the build issue with ESP-IDF v5.x. Component dependency must be explicitly specified, earlier this might be getting resolved through other components.