### PR TITLE
Support specifying a CPU core ID

### DIFF
--- a/audio_player.cpp
+++ b/audio_player.cpp
@@ -566,7 +566,7 @@ esp_err_t audio_player_new(audio_player_config_t config)
                                 &instance,
         (UBaseType_t)           instance.config.priority,
         (TaskHandle_t * const)  NULL,
-                                0);
+        (BaseType_t)            instance.config.coreID);
 
     ESP_GOTO_ON_FALSE(pdPASS == task_val, ESP_ERR_NO_MEM, cleanup,
         TAG, "Failed create audio task");

--- a/include/audio_player.h
+++ b/include/audio_player.h
@@ -158,6 +158,7 @@ typedef struct {
     audio_reconfig_std_clock clk_set_fn;
     audio_player_write_fn write_fn;
     UBaseType_t priority; /*< FreeRTOS task priority */
+    BaseType_t coreID; /*< ESP32 core ID */
 } audio_player_config_t;
 
 /**

--- a/test/audio_player_test.c
+++ b/test/audio_player_test.c
@@ -100,7 +100,8 @@ TEST_CASE("audio player can be newed and deleted", "[audio player]")
     audio_player_config_t config = { .mute_fn = audio_mute_function,
                                      .write_fn = bsp_i2s_write,
                                      .clk_set_fn = bsp_i2s_reconfig_clk,
-                                     .priority = 0 };
+                                     .priority = 0,
+                                     .coreID = 0 };
     esp_err_t ret = audio_player_new(config);
     TEST_ASSERT_EQUAL(ret, ESP_OK);
 
@@ -174,7 +175,8 @@ TEST_CASE("audio player states and callbacks are correct", "[audio player]")
     audio_player_config_t config = { .mute_fn = audio_mute_function,
                                      .write_fn = bsp_i2s_write,
                                      .clk_set_fn = bsp_i2s_reconfig_clk,
-                                     .priority = 0 };
+                                     .priority = 0,
+                                     .coreID = 0 };
     ret = audio_player_new(config);
     TEST_ASSERT_EQUAL(ret, ESP_OK);
 


### PR DESCRIPTION
This is handy in situations where the default core 0 is being used by something else.