### PR TITLE
fix: build warning for type qualifiers

### DIFF
--- a/audio_player.cpp
+++ b/audio_player.cpp
@@ -565,7 +565,7 @@ esp_err_t audio_player_new(audio_player_config_t config)
                                 4 * 1024,
                                 &instance,
         (UBaseType_t)           instance.config.priority,
-        (TaskHandle_t * const)  NULL,
+        (TaskHandle_t *)  NULL,
         (BaseType_t)            instance.config.coreID);
 
     ESP_GOTO_ON_FALSE(pdPASS == task_val, ESP_ERR_NO_MEM, cleanup,


### PR DESCRIPTION
Closes https://github.com/chmorgan/esp-audio-player/issues/8