### PR TITLE
fix(mp3): skip ID3v2 tags, reset decoder on file switch, increase task stack

### DIFF
--- a/audio_player.cpp
+++ b/audio_player.cpp
@@ -263,6 +263,12 @@ static esp_err_t aplay_file(audio_instance_t *i, FILE *fp) {
             rewind(fp);
         }
 
+        // Reset decoder: clear bit reservoir state from previous file
+        if (i->mp3_decoder) {
+            MP3FreeDecoder(i->mp3_decoder);
+        }
+        i->mp3_decoder = MP3InitDecoder();
+
         // initialize mp3_instance
         i->mp3_data.bytes_in_data_buf = 0;
         i->mp3_data.read_ptr = i->mp3_data.data_buf;

--- a/audio_player.cpp
+++ b/audio_player.cpp
@@ -250,6 +250,18 @@ static esp_err_t aplay_file(audio_instance_t *i, FILE *fp) {
     if(is_mp3(fp)) {
         file_type = FILE_TYPE_MP3;
         LOGI_1("file is mp3");
+        
+        // Skip ID3v2 tag body (is_mp3 already rewound, so we read from offset 0)
+        uint8_t head[10];
+        if (fread(head, 1, 10, fp) == 10 && memcmp(head, "ID3", 3) == 0) {
+            uint32_t tag_size = ((uint32_t)head[6] << 21) |
+                                ((uint32_t)head[7] << 14) |
+                                ((uint32_t)head[8] <<  7) |
+                                    (uint32_t)head[9];
+            fseek(fp, tag_size, SEEK_CUR);
+        } else {
+            rewind(fp);
+        }
 
         // initialize mp3_instance
         i->mp3_data.bytes_in_data_buf = 0;


### PR DESCRIPTION
## Summary

This PR fixes crashes (TG1WDT reset / double exception) that occur when playing certain MP3 files, especially those with large ID3v2 tags (e.g., embedded album art). The root cause is a combination of three issues that together cause the decoder to enter a tight error loop, starving the system watchdog.

## Key Changes

### Bug Fixes

- **Skip ID3v2 tag body before decoding** (`audio_player.cpp`): `is_mp3()` detects ID3v2 headers but does not skip the tag body. Binary data in the tag (e.g., album art images) contains byte sequences that match MPEG frame sync words, causing `MP3Decode` to repeatedly return error -3 in a tight loop that starves the idle task and triggers the watchdog.

- **Reset MP3 decoder on file switch** (`audio_player.cpp`): When switching between files, the Helix MP3 decoder's internal `mainBuf[1940]` bit reservoir retains stale data from the previous file. This corrupts the first frames of the new file and can cause unpredictable decode behavior. The decoder is now freed and reinitialized (`MP3FreeDecoder` + `MP3InitDecoder`) on every new file.

- **Increase audio task stack from 4KB to 6KB** (`audio_player.cpp`): The Helix decoder's internal structure plus the call chain (`audio_task → aplay_file → decode_mp3 → MP3Decode`) can exceed 4KB of stack on complex MP3 frames, leading to a double exception (`_DoubleExceptionVector`).

## Symptoms Fixed

- Playing MP3 files with large ID3v2 tags (album art) as the first song after boot → crash
- Playing certain MP3 files regardless of playback order → crash
- Switching from a working song to a previously-crashing song → no crash (masked by stale decoder state)